### PR TITLE
Log cleanup

### DIFF
--- a/slackminion/bot.py
+++ b/slackminion/bot.py
@@ -262,7 +262,6 @@ class Bot(object):
 
     # Parse incoming event and return a corresponding SlackEvent object
     async def _parse_event(self, payload):
-        # self.log.debug(payload)
         event_type, data = self._unpack_payload(**payload)
         subtype = data.get("subtype")
 

--- a/slackminion/bot.py
+++ b/slackminion/bot.py
@@ -348,7 +348,7 @@ class Bot(object):
         try:
             self.log.debug(f"Sending to dispatcher: {msg}")
             cmd, output, cmd_options = await self.dispatcher.push(msg, self.dev_mode)
-            self.log.debug(f"Output from dispatcher: {output}")
+            self.log.info(f"Output from dispatcher: {output}")
 
             if output:
                 await self._prepare_and_send_output(cmd, msg, cmd_options, output)

--- a/slackminion/plugins/core/__init__.py
+++ b/slackminion/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-version = "2.0.2"
+version = "2.0.3"

--- a/slackminion/tests/test_bot.py
+++ b/slackminion/tests/test_bot.py
@@ -85,7 +85,7 @@ class TestBot(unittest.TestCase):
         self.object._parse_event.assert_called_with(test_payload)
         self.object._load_user_rights.assert_not_called()
         self.object.dispatcher.push.assert_called_with(self.test_event, False)
-        self.object.log.debug.assert_called_with(
+        self.object.log.info.assert_called_with(
             f"Output from dispatcher: {test_output}"
         )
         self.object._prepare_and_send_output.assert_called_with(
@@ -115,7 +115,7 @@ class TestBot(unittest.TestCase):
         self.object._parse_event.assert_called_with(test_payload)
         self.object._load_user_rights.assert_not_called()
         self.object.dispatcher.push.assert_called_with(self.test_event, False)
-        self.object.log.debug.assert_called_with(
+        self.object.log.info.assert_called_with(
             f"Output from dispatcher: {test_output}"
         )
         self.object._prepare_and_send_output.assert_called_with(
@@ -147,7 +147,7 @@ class TestBot(unittest.TestCase):
 
         self.object._parse_event.assert_called_with(test_payload)
         self.object.dispatcher.push.assert_called_with(self.test_event, False)
-        self.object.log.debug.assert_called_with(
+        self.object.log.info.assert_called_with(
             f"Output from dispatcher: {test_output}"
         )
         self.object._prepare_and_send_output.assert_called_with(
@@ -176,7 +176,7 @@ class TestBot(unittest.TestCase):
         self.object._parse_event.assert_called_with(test_payload)
         self.object._load_user_rights.assert_not_called()
         self.object.dispatcher.push.assert_called_with(self.test_event, False)
-        self.object.log.debug.assert_called_with(
+        self.object.log.info.assert_called_with(
             f"Output from dispatcher: {test_output}"
         )
         self.object._prepare_and_send_output.assert_called_with(


### PR DESCRIPTION
Overview of this PR: Slackminion calls slack_sdk, where we wanted to keep the granularity of different levels of logs, but be able to differentiate the logger level. 
To keep slack_sdk debug logs as DEBUG.
And bumping up all Slackminion DEBUG to INFO.

Test:
`tox`
test result: https://phabricator.pinadmin.com/P15263

Henrique could you help me to take a look of the tox result, py3 is passing, but both isort and black has some import order issue. 